### PR TITLE
Fixes restart of games

### DIFF
--- a/CMakeSettings.json
+++ b/CMakeSettings.json
@@ -20,8 +20,7 @@
             "cmakeCommandArgs": "",
             "buildCommandArgs": "",
             "ctestCommandArgs": "",
-            "inheritEnvironments": [ "msvc_x64_x64" ],
-            "variables": []
+            "inheritEnvironments": [ "msvc_x64_x64" ]
         }
     ]
 }

--- a/src/block_breaker.cpp
+++ b/src/block_breaker.cpp
@@ -267,6 +267,7 @@ namespace TerminalMinigames
 				{
 					update_ball = std::thread(UpdateBall, std::ref(screen), std::ref(game_state), back_to_menu);
 					restart_flag = false;
+					screen.PostEvent(ftxui::Event::Custom);
 				}
 				if (update_ball.joinable())
 				{

--- a/src/snake_game.cpp
+++ b/src/snake_game.cpp
@@ -398,6 +398,7 @@ namespace TerminalMinigames
                 {
                     update_snake = std::thread(Update, std::ref(screen), std::ref(game_state), back_to_menu);
                     restart_flag = false;
+                    screen.PostEvent(ftxui::Event::Custom);
                 }
                 if (update_snake.joinable())
                 {


### PR DESCRIPTION
Fixes an issue where the game's screen is not refreshed after clicking the Restart button of Snake and Block Breaker.